### PR TITLE
Temporarily fix to whitepaper links

### DIFF
--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -12,14 +12,14 @@
             <div class="footer-nav">
                 <h3>XKR</h3>
                 <a href="https://explorer.kryptokrona.se" class="footer-link"><p>Explorer</p></a>
-                <a href="/" class="footer-link"><p>Whitepaper</p></a>
+                <a href="https://kryptokrona.se/Proposal_for_a_New_Nordic_Digital_Currency.pdf" class="footer-link"><p>Whitepaper</p></a>
                 <a href="/blog" class="footer-link"><p>Blog</p></a>
                 <a href="/https://docs.kryptokrona.org" class="footer-link"><p>Guides</p></a>
                 <a href="https://github.com/kryptokrona" class="footer-link"><p>Github</p></a>
             </div>
             <div class="footer-nav">
                 <h3>Hugin</h3>
-                <a href="/" class="footer-link"><p>Whitepaper</p></a>
+                <a href="https://kryptokrona.se/Hugin_Whitepaper.pdf" class="footer-link"><p>Whitepaper</p></a>
                 <a href="/faucet" class="footer-link"><p>Faucet</p></a>
                 <a href="https://github.com/kryptokrona/hugin-messenger" class="footer-link"><p>Github</p></a>
             </div>


### PR DESCRIPTION
Linked the whitepaper to the whitepaper on kryptokrona.se so newcomers can click it. Will later be fixed with implimenting the pdf into the website. But for now, use this