### PR TITLE
Download terminal wallet does not have a link to it

### DIFF
--- a/src/routes/blog/devaluation.md
+++ b/src/routes/blog/devaluation.md
@@ -15,4 +15,4 @@ Total Supply of XKR: 1 000 000 000,00000 XKR
 
 Decimals: 5, that is, 1,00000
 
-As a user you only need to update your wallet software, which is automatic, with exception for the terminal wallet which you can download here
+As a user you only need to update your wallet software, which is automatic, with exception for the terminal wallet which you can download [here] (https://github.com/kryptokrona/kryptokrona/releases)


### PR DESCRIPTION
It says, download the terminal wallet here, but there is no link. I think it is fixed now with using the «here» button as a link to the terminal wallet