### PR TITLE
Added Extra to the footer

### DIFF
--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -23,6 +23,14 @@
                 <a href="/faucet" class="footer-link"><p>Faucet</p></a>
                 <a href="https://github.com/kryptokrona/hugin-messenger" class="footer-link"><p>Github</p></a>
             </div>
+            <div class="footer-nav">
+              <h3>Extra</h3>
+              <a href="https://github.com/kryptokrona/kryptokrona-stickers" class="footer-link"><p>Stickers</p></a>
+              <a href="https://kryptokrona.se/store/" class="footer-link"><p>Store</p></a>
+              <a href="https://docs.kryptokrona.se/" class="footer-link"><p>Docs</p></a>
+              <a href="https://www.exbitron.com/trading/xkrusdt" class="footer-link"><p>Exchange</p></a>
+          </div>
+          <div class ="footer-nav">
         </div>
         <div class="other">
             <p>Developed by Swepool</p>


### PR DESCRIPTION
Take a look at this. I added an extra class to the website. It contains information about the stickers (coming soon, I am going to make a /sticker for it) and a little about the docs and the store we got. Later we can add these into the .org domain but for now, we can just link it. 

Another thought I also had was that when we begin with the marketing, we need a big button that says "BUY". If I were completely new and went on the website I would have no idea how to buy XKR. I can later today make a comprehensive guide on how to buy XKR on Exbitron. 

With the button in mind, we as a community need to agree on where it should be.  