### PR TITLE
Updating /mining

### DIFF
--- a/src/routes/mining/index.svelte
+++ b/src/routes/mining/index.svelte
@@ -11,18 +11,31 @@
 
     <div class="text-wrapper">
         <p>Kryptokrona is a cryptocurrency that relies on proof-of-work mining to achieve distributed consensus. It utilizes the Cryptonight Turtle algorithm. This algorithm is primarily mined on CPUs and is ASIC resistant. With Kryptokrona being ASIC resistant, the whole network gets decentralized. This means that the algorithm is purposefully designed to stop mining from being dominated by a set of specialized miners with the most expensive equipment. Therefore Kryptokrona should be easily mineable through "regular" computers.</p>
-        <h2>Hardware</h2>
-        <p>Kryptokrona can be mined on CPUs, GPUs & Android Phones. </p>
+        <h2>Hardwate for mining</h2>
+        <p>You can mine Kryptokrona on CPUs, GPUs & Android Phones. Compare your hashrate to others, and even help expand the list!</p>
+        <br>
+        <LinkButton url="https://kryptokrona.org/benchmarks" target="_blank" enabled={false} text="Kryptokrona Benchmarks"/> 
+        <br>
+        <br>
         <h2>Software</h2>
         <p>There are several options when it comes to mining software.The most common mining software for mining such algorithms is XMRig. Guide on how to mine XKR is coming up soon.</p>
     </div>
 
-    <LinkButton url="https://xmrig.com/download" target="_blank" enabled={true} text="Download XMRig"/>
+    <LinkButton url="https://xmrig.com/download" target="_blank" enabled={false} text="Download XMRig"/>
 
     <div class="tools">
         <MiningConfig/>
         <MiningCalc/>
     </div>
+
+    <div class="text-wrapper">
+      <h2>Don't want to mine?</h2>
+      <p>Buy XKR here. We are working on listing XKR at other places.</p>
+    </div>
+    <LinkButton url="https://kryptokrona.org/blog/how-to-buy-xkr" target="_blank" enabled={false} text="Guide on how to buy XKR"/> 
+    <br>
+    <br>
+    <br>
 
     <div class="text-wrapper">
       <h2>Support</h2>
@@ -32,11 +45,7 @@
     <JoinDiscord/>
     <StatusBar/>
     
-    <div class="text-wrapper">
-      <h2>Don't want to mine?</h2>
-      <p>Buy XKR here. We are working on listing XKR at other places.</p>
-    </div>
-    <LinkButton url="https://kryptokrona.org/blog/how-to-buy-xkr" target="_blank" enabled={false} text="Guide on how to buy XKR"/> 
+    
 </div>
 
 


### PR DESCRIPTION
When users comes to the mining tab, they can't see the /benchmarks. Now that is fixed with a little text and a button to it. Later I can add a button for it on the footer of the website.